### PR TITLE
Fix get team members (resolves #23)

### DIFF
--- a/berserk/clients.py
+++ b/berserk/clients.py
@@ -253,7 +253,7 @@ class Users(BaseClient):
         :return: users on the given team
         :rtype: iter
         """
-        path = f'team/{team_id}/users'
+        path = f'api/team/{team_id}/users'
         return self._r.get(path, fmt=NDJSON, stream=True,
                            converter=models.User.convert)
 
@@ -308,7 +308,7 @@ class Teams(BaseClient):
         :return: users on the given team
         :rtype: iter
         """
-        path = f'team/{team_id}/users'
+        path = f'api/team/{team_id}/users'
         return self._r.get(path, fmt=NDJSON, stream=True,
                            converter=models.User.convert)
 


### PR DESCRIPTION
Previously the API returned a 404 error since the URL was incorrect, the correct url is given by the Lichess API documentation. ([https://lichess.org/api#operation/teamIdUsers](https://lichess.org/api#operation/teamIdUsers))

Resolves #23 