### PR TITLE
Added TV streaming

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,6 +95,7 @@ Most if not all of the API is available:
     client.board.stream_incoming_events
     client.board.seek
     client.board.stream_game_state
+    client.board.stream_tv_game
     client.board.make_move
     client.board.post_message
     client.board.abort_game

--- a/berserk/clients.py
+++ b/berserk/clients.py
@@ -693,6 +693,15 @@ class Board(BaseClient):
         yield from self._r.get(path, stream=True,
                                converter=models.GameState.convert)
 
+    def stream_tv_game(self):
+        """Get the stream of events for the current game on Lichess TV.
+
+        :return iterator over game states
+        """
+        path = 'api/tv/feed'
+        yield from self._r.get(path, stream=True,
+                               converter=models.GameState.convert)
+
     def make_move(self, game_id, move):
         """Make a move in a board game.
 


### PR DESCRIPTION
Added a function `stream_tv_game()` in clients.py that gets an iterator over gave states for the current featured TV game.

This is very similar to the function `stream_game_state()`, but it uses the `api/tv/feed` endpoint instead of `api/board/game/stream/{game_id}`.